### PR TITLE
Test transformations

### DIFF
--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -584,8 +584,7 @@ class NXRefine(object):
         i.e., t_gs. From this is subtracted the vector from the goniometer 
         center to the detector center, i.e., t_gd
         """
-        Svec = vec(0.0)
-        return Svec - vec(self.distance)
+        return vec(-self.distance)
 
     @property
     def Evec(self):

--- a/src/nxrefine/nxrefine.py
+++ b/src/nxrefine/nxrefine.py
@@ -558,9 +558,7 @@ class NXRefine(object):
         It also transforms detector coords into lab coords.
         Operation order:    yaw -> pitch -> roll -> twotheta -> gonpitch
         """
-        return inv(rotmat(2, self.gonpitch) *
-                   rotmat(3, self.twotheta) *
-                   rotmat(1, self.roll) *
+        return inv(rotmat(1, self.roll) *
                    rotmat(2, self.pitch) *
                    rotmat(3, self.yaw))
 
@@ -587,10 +585,7 @@ class NXRefine(object):
         center to the detector center, i.e., t_gd
         """
         Svec = vec(0.0)
-        return (self.Gmat(phi) * Svec
-                - (rotmat(2,self.gonpitch) * 
-                   rotmat(3,self.twotheta) * 
-                   vec(self.distance)))
+        return Svec - vec(self.distance)
 
     @property
     def Evec(self):

--- a/src/nxrefine/plugins/refine/find_maximum.py
+++ b/src/nxrefine/plugins/refine/find_maximum.py
@@ -52,7 +52,7 @@ class MaximumDialog(BaseDialog):
         else:
             self.progress_bar.setVisible(True)
             self.progress_bar.setRange(0, signal.shape[0])
-            chunk_size = signal.nxfile[signal.nxpath].chunks[0]
+            chunk_size = signal.chunks[0]
             for i in range(0, signal.shape[0], chunk_size):
                 try:
                     self.progress_bar.setValue(i)

--- a/src/nxrefine/plugins/refine/find_peaks.py
+++ b/src/nxrefine/plugins/refine/find_peaks.py
@@ -105,7 +105,7 @@ class FindDialog(BaseDialog):
         if len(field.shape) == 2:
             res = None
         else:
-            chunk_size = field.nxfile[field.nxpath].chunks[0]
+            chunk_size = field.chunks[0]
             z_min, z_max = self.get_limits()
             pixel_tolerance, frame_tolerance = self.get_tolerance()
             self.progress_bar.setRange(z_min, z_max)

--- a/src/nxrefine/scripts/nxcombine.py
+++ b/src/nxrefine/scripts/nxcombine.py
@@ -75,6 +75,8 @@ def main():
                   ('Current machine: %s\n'
                    'Current working directory: %s')
                     % (socket.gethostname(), os.getcwd()))
+    if 'nxcombine' in entry:
+        del entry['nxcombine']
     entry['nxcombine'] = NXprocess(program='nxcombine', 
                                    sequence_index=len(entry.NXprocess)+1, 
                                    version=__version__, 

--- a/src/nxrefine/scripts/nxfind.py
+++ b/src/nxrefine/scripts/nxfind.py
@@ -26,7 +26,8 @@ def find_peaks(group, threshold=None, z_min=None, z_max=None):
         elif 'maximum' in field.attrs:
             threshold = np.float32(field.maximum) / 20
         else:
-            raise NeXusError('Must give threshold if the field maximum is unknown')
+            raise NeXusError(
+                'Must give threshold if the field maximum is unknown')
 
     if z_min == None:
         z_min = 0
@@ -38,7 +39,7 @@ def find_peaks(group, threshold=None, z_min=None, z_max=None):
     if len(field.shape) == 2:
         res = None
     else:
-        chunk_size = field.nxfile[field.nxpath].chunks[0]
+        chunk_size = field.chunks[0]
         pixel_tolerance = 50
         frame_tolerance = 10
         for i in range(0, field.shape[0], chunk_size):

--- a/src/nxrefine/scripts/nxmax.py
+++ b/src/nxrefine/scripts/nxmax.py
@@ -23,7 +23,7 @@ def find_maximum(field):
     if len(field.shape) == 2:
         maximum = field[:,:].max()
     else:
-        chunk_size = field.nxfile[field.nxpath].chunks[0]
+        chunk_size = field.chunks[0]
         for i in range(0, field.shape[0], chunk_size):
             try:
                 print 'Processing', i


### PR DESCRIPTION
* Removes twotheta and gonpitch from the Dmat and Dvec. These two angles are not coupled in our configuration because the detector is not on a two-theta arm.
* Removes the previous record of nxcombine when a CCTW merge is repeated.
* Uses the NXfield chunks property, rather than reading chunk sizes from the file.